### PR TITLE
Make RSpec headings more consistent

### DIFF
--- a/spec/features/applications/admin_show_spec.rb
+++ b/spec/features/applications/admin_show_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Approving/rejecting applications' do
+RSpec.describe 'the admin application show' do
   before :each do
     @app1 = Application.create!(fname: 'John', lname: 'Smithson', street_address: '12324 Turing Blvd.', city: 'Dtown', state: 'CO', zip_code: 12345, good_home_argument: 'Because reasons', status: "Pending" )
 
@@ -47,10 +47,11 @@ RSpec.describe 'Approving/rejecting applications' do
         visit "/admin/applications/#{@app1.id}"
 
         click_button "Approve #{@pet4.name} Adoption"
-        
+
         within "#pet_#{@pet4.id}" do
           expect(page).to have_content("Adoption Approved")
           expect(page).to_not have_button("Approve #{@pet4.name} Adoption")
+          expect(page).to_not have_button("Reject #{@pet4.name} Adoption")
         end
       end
 
@@ -79,7 +80,9 @@ RSpec.describe 'Approving/rejecting applications' do
 
         within "#pet_#{@pet4.id}" do
           expect(page).to have_content("Adoption Rejected")
+          expect(page).to_not have_content("Adoption Approved")
           expect(page).to_not have_button("Reject #{@pet4.name} Adoption")
+          expect(page).to_not have_button("Accept #{@pet4.name} Adoption")
         end
       end
     end
@@ -96,11 +99,15 @@ RSpec.describe 'Approving/rejecting applications' do
 
           within "#pet_#{@pet1.id}" do
             expect(page).to_not have_content("Adoption Approved")
+            expect(page).to_not have_content("Adoption Rejected")
             expect(page).to have_button("Approve #{@pet1.name} Adoption")
+            expect(page).to have_button("Reject #{@pet1.name} Adoption")
           end
 
           within "#pet_#{@pet5.id}" do
+            expect(page).to_not have_content("Adoption Approved")
             expect(page).to_not have_content("Adoption Rejected")
+            expect(page).to have_button("Approve #{@pet5.name} Adoption")
             expect(page).to have_button("Reject #{@pet5.name} Adoption")
           end
         end
@@ -112,6 +119,7 @@ RSpec.describe 'Approving/rejecting applications' do
         visit "/admin/applications/#{@app2.id}"
 
         within "#application_#{@app2.id}" do
+          expect(page).to have_content("Pending")
           expect(page).to_not have_content("Accepted")
         end
 
@@ -119,6 +127,7 @@ RSpec.describe 'Approving/rejecting applications' do
         click_button "Approve #{@pet5.name} Adoption"
 
         within "#application_#{@app2.id}" do
+          expect(page).to_not have_content("Pending")
           expect(page).to have_content("Accepted")
         end
       end
@@ -129,6 +138,7 @@ RSpec.describe 'Approving/rejecting applications' do
         visit "/admin/applications/#{@app2.id}"
 
         within "#application_#{@app2.id}" do
+          expect(page).to have_content("Pending")
           expect(page).to_not have_content("Rejected")
         end
 
@@ -136,6 +146,7 @@ RSpec.describe 'Approving/rejecting applications' do
         click_button "Approve #{@pet5.name} Adoption"
 
         within "#application_#{@app2.id}" do
+          expect(page).to_not have_content("Pending")
           expect(page).to have_content("Rejected")
         end
       end
@@ -177,10 +188,12 @@ RSpec.describe 'Approving/rejecting applications' do
 
         within "#pet_#{@pet1.id}" do
           expect(page).to_not have_button("Approve #{@pet1.name} Adoption")
+          expect(page).to have_button("Reject #{@pet1.name} Adoption")
         end
 
         within "#pet_#{@pet5.id}" do
           expect(page).to_not have_button("Approve #{@pet5.name} Adoption")
+          expect(page).to have_button("Reject #{@pet5.name} Adoption")
         end
       end
 
@@ -193,11 +206,13 @@ RSpec.describe 'Approving/rejecting applications' do
         visit "/admin/applications/#{@app1.id}"
 
         within "#pet_#{@pet1.id}" do
+          expect(page).to_not have_button("Approve #{@pet1.name} Adoption")
           expect(page).to have_content("*Already approved for adoption*")
           expect(page).to have_button("Reject #{@pet1.name} Adoption")
         end
 
         within "#pet_#{@pet5.id}" do
+          expect(page).to_not have_button("Approve #{@pet5.name} Adoption")
           expect(page).to have_content("*Already approved for adoption*")
           expect(page).to have_button("Reject #{@pet5.name} Adoption")
         end

--- a/spec/features/applications/create_spec.rb
+++ b/spec/features/applications/create_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'the pets index' do
+RSpec.describe 'application create' do
   before :each do
     @app1 = Application.create!(fname: 'John', lname: 'Smithson', street_address: '12324 Turing Blvd.', city: 'Dtown', state: 'CO', zip_code: 12345, good_home_argument: 'Because reasons', status: "In Progress" )
 
@@ -47,6 +47,9 @@ RSpec.describe 'the pets index' do
           expect(page).to have_content("State")
           expect(page).to have_content("Zip Code")
           expect(page).to have_button("Submit")
+
+          expect(page).to_not have_content("Pet Name")
+          expect(page).to_not have_content("Shelter Name")
         end
 
         it "Submit takes user to application's show page (another test same as this in spec/features/applications/show_spec.rb)" do
@@ -120,6 +123,8 @@ RSpec.describe 'the pets index' do
           click_button 'Submit'
 
           expect(page).to have_content("You must fill out all fields to submit the application")
+          expect(page).to_not have_content("In Progress")
+          expect(page).to_not have_content("Pending")
         end
       end
     end

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
-RSpec.describe Pet, type: :model do
+RSpec.describe 'the application show' do
   before :each do
     @app1 = Application.create!(fname: 'John', lname: 'Smithson', street_address: '12324 Turing Blvd.', city: 'Dtown', state: 'CO', zip_code: 12345, good_home_argument: 'Because reasons', status: "Pending" )
-    @app2 = Application.create!(fname: 'John', lname: 'Smith', street_address: '1234 Turig Blvd.', city: 'Ttown', state: 'CO', zip_code: 12345, good_home_argument: 'Because reasonsable', status: "In Progress" )
+    @app2 = Application.create!(fname: 'Jerry', lname: 'Lewis', street_address: '1234 Turig Blvd.', city: 'Ttown', state: 'CO', zip_code: 12345, good_home_argument: 'Because reasonsable', status: "In Progress" )
     @shelter1 = Shelter.create!(foster_program: true, name: 'Happy Shelter', city: 'Dmetro', rank: 3 )
 
     @pet1 = @shelter1.pets.create!(adoptable: true, age: 5, breed: 'dog', name: 'Roofus')
@@ -26,36 +26,40 @@ RSpec.describe Pet, type: :model do
           visit "/applications/#{@app1.id}"
 
           expect(page).to have_content("#{@app1.fname} #{@app1.lname}")
+          expect(page).to_not have_content("#{@app2.fname} #{@app2.lname}")
         end
 
         it 'displays full address' do
           visit "/applications/#{@app1.id}"
 
-          expect(page).to have_content("#{@app1.street_address}")
+          expect(page).to have_content(@app1.street_address)
           expect(page).to have_content("#{@app1.city}, #{@app1.state} #{@app1.zip_code}")
+          expect(page).to_not have_content(@app2.status)
         end
 
         it 'displays description of good home arg' do
           visit "/applications/#{@app1.id}"
 
-          expect(page).to have_content("#{@app1.good_home_argument}")
+          expect(page).to have_content(@app1.good_home_argument)
         end
 
         it 'displays all pet names application is for and is linked' do
           visit "/applications/#{@app1.id}"
 
-          expect(page).to have_content("#{@app1.pets.first.name}")
-          expect(page).to_not have_content("#{@pet2.name}")
-          expect(page).to have_link("#{@app1.pets.first.name}")
+          expect(page).to have_content(@app1.pets.first.name)
+          expect(page).to have_link(@app1.pets.first.name)
 
-          click_link("#{@app1.pets.first.name}")
+          expect(page).to_not have_content(@pet2.name)
+
+          click_link(@app1.pets.first.name)
+
           expect(current_path).to eq("/pets/#{@app1.pets.first.id}")
         end
 
         it 'displays app status' do
           visit "/applications/#{@app1.id}"
 
-          expect(page).to have_content("#{@app1.status}")
+          expect(page).to have_content(@app1.status)
         end
       end
 
@@ -70,14 +74,14 @@ RSpec.describe Pet, type: :model do
 
           it 'a search for Pets by name with input' do
             visit "/applications/#{@app2.id}"
-            
+
             expect(page).to have_content('Search For Your Future Pet!')
             expect(page).to have_button('Search All Pets')
           end
 
           it 'a search returns pets with that name on the show page' do
             visit "/applications/#{@app2.id}"
-            
+
             fill_in 'Search For Your Future Pet!', with: 'Nacho'
             click_button 'Search All Pets'
 
@@ -89,7 +93,7 @@ RSpec.describe Pet, type: :model do
 
           it 'a search returns pets with that name that partially match search' do
             visit "/applications/#{@app2.id}"
-            
+
             fill_in 'Search For Your Future Pet!', with: 'Na'
             click_button 'Search All Pets'
 
@@ -138,7 +142,7 @@ RSpec.describe Pet, type: :model do
 
             expect(current_path).to eq("/applications/#{@app2.id}")
           end
-          
+
           it 'Adopt pet button is clicked and returns to show page' do
             visit "/applications/#{@app2.id}"
 

--- a/spec/features/shelters/admin_index_spec.rb
+++ b/spec/features/shelters/admin_index_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Approving/rejecting applications' do
+RSpec.describe 'the shelter admin index' do
   before :each do
     @app1 = Application.create!(fname: 'John', lname: 'Smithson', street_address: '12324 Turing Blvd.', city: 'Dtown', state: 'CO', zip_code: 12345, good_home_argument: 'Because reasons', status: "Pending" )
     @app2 = Application.create!(fname: 'John', lname: 'Smith', street_address: '1234 Turig Blvd.', city: 'Ttown', state: 'CO', zip_code: 12345, good_home_argument: 'Because reasonsable', status: "Pending" )

--- a/spec/features/shelters/admin_show_spec.rb
+++ b/spec/features/shelters/admin_show_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Approving/rejecting applications' do
+RSpec.describe 'the shelter admin show' do
   before :each do
     @app1 = Application.create!(fname: 'John', lname: 'Smithson', street_address: '12324 Turing Blvd.', city: 'Dtown', state: 'CO', zip_code: 12345, good_home_argument: 'Because reasons', status: "Pending" )
     @app2 = Application.create!(fname: 'John', lname: 'Smith', street_address: '1234 Turig Blvd.', city: 'Ttown', state: 'CO', zip_code: 12345, good_home_argument: 'Because reasonsable', status: "Pending" )
@@ -62,6 +62,7 @@ RSpec.describe 'Approving/rejecting applications' do
           visit "/admin/shelters/#{@shelter1.id}"
 
           expect(page).to have_content("Number of Adoptable Pets: 2")
+          expect(page).to_not have_content("Number of Adoptable Pets: 3")
         end
 
         it 'displays tht count of the number of pets adopted from a shelter' do
@@ -77,10 +78,13 @@ RSpec.describe 'Approving/rejecting applications' do
         it 'that have a pending application and havent been marked approved/rejected' do
           @app3 = Application.create!(fname: 'ohn', lname: 'mith', street_address: '234 Turig Blvd.', city: 'Ttown', state: 'CO', zip_code: 12345, good_home_argument: 'Because reasonsae', status: "Pending" )
           @app4 = Application.create!(fname: 'hn', lname: 'ith', street_address: '34 Turig Blvd.', city: 'Ttown', state: 'CO', zip_code: 12345, good_home_argument: 'Because reasonsa', status: "Pending" )
+
           @shelter_2 = Shelter.create(name: 'RGV animal shelter', city: 'Harlingen, TX', foster_program: false, rank: 5)
           @shelter_3 = Shelter.create(name: 'Fancy pets of Colorado', city: 'Denver, CO', foster_program: true, rank: 10)
+
           @pet_4 = @shelter_2.pets.create(name: 'Ann', breed: 'ragdoll', age: 5, adoptable: true)
           @pet_5 = @shelter_3.pets.create(name: 'Banann', breed: 'doll', age: 7, adoptable: true)
+
           @app3.pets << @pet_4
           @app4.pets << @pet_5
           @app2.pets << @pet2
@@ -95,6 +99,8 @@ RSpec.describe 'Approving/rejecting applications' do
             expect(page).to have_content("#{@pet2.name} on app #{@app1.id}")
             expect(page).to have_content("#{@pet2.name} on app #{@app2.id}")
             expect(page).to have_content("#{@pet2.name} on app #{@app3.id}")
+
+            expect(page).to_not have_content("#{@pet4.name} on app #{@app3.id}")
           end
         end
 
@@ -111,21 +117,27 @@ RSpec.describe 'Approving/rejecting applications' do
           @app3.pets << @pet2
 
           visit "/admin/shelters/#{@shelter1.id}"
+
           within "#actionrequired" do
             click_link("#{@pet1.name} on app #{@app1.id}")
           end
+
           expect(current_path).to eq("/admin/applications/#{@app1.id}")
 
           visit "/admin/shelters/#{@shelter1.id}"
+
           within "#actionrequired" do
             click_link("#{@pet2.name} on app #{@app1.id}")
           end
+
           expect(current_path).to eq("/admin/applications/#{@app1.id}")
 
           visit "/admin/shelters/#{@shelter1.id}"
+
           within "#actionrequired" do
             click_link("#{@pet2.name} on app #{@app2.id}")
           end
+          
           expect(current_path).to eq("/admin/applications/#{@app2.id}")
         end
       end


### PR DESCRIPTION
Make RSpec headings more consistent, add more .to_not in testing for edge verification.